### PR TITLE
BE : Analysis and Implementation Email Domain approval from SPV Portal

### DIFF
--- a/src/main/java/org/sunbird/workflow/config/Constants.java
+++ b/src/main/java/org/sunbird/workflow/config/Constants.java
@@ -243,5 +243,5 @@ public class Constants {
 	public static final String CONTEXT_TYPE = "contextType";
 	public static final String CONTEXT_NAME = "contextName";
 	public static final String USER_REGISTRATION_PRE_APPROVED_DOMAIN = "userRegistrationPreApprovedDomain";
-	public static final String DOMAIN_NAME_REQUEST_ALREADY_ERROR_MSG = "Already A Request is raised for Domain";
+	public static final String DOMAIN_NAME_REQUEST_ALREADY_ERROR_MSG = "Already a request is raised for domain";
 }

--- a/src/main/java/org/sunbird/workflow/config/Constants.java
+++ b/src/main/java/org/sunbird/workflow/config/Constants.java
@@ -243,4 +243,5 @@ public class Constants {
 	public static final String CONTEXT_TYPE = "contextType";
 	public static final String CONTEXT_NAME = "contextName";
 	public static final String USER_REGISTRATION_PRE_APPROVED_DOMAIN = "userRegistrationPreApprovedDomain";
+	public static final String DOMAIN_NAME_REQUEST_ALREADY_ERROR_MSG = "Already A Request is raised for Domain";
 }

--- a/src/main/java/org/sunbird/workflow/config/Constants.java
+++ b/src/main/java/org/sunbird/workflow/config/Constants.java
@@ -243,5 +243,5 @@ public class Constants {
 	public static final String CONTEXT_TYPE = "contextType";
 	public static final String CONTEXT_NAME = "contextName";
 	public static final String USER_REGISTRATION_PRE_APPROVED_DOMAIN = "userRegistrationPreApprovedDomain";
-	public static final String DOMAIN_NAME_REQUEST_ALREADY_ERROR_MSG = "Already a request is raised for domain";
+	public static final String DOMAIN_NAME_REQUEST_EXIST_MSG = "Already a request is raised for domain";
 }

--- a/src/main/java/org/sunbird/workflow/controller/DomainWorkFlowController.java
+++ b/src/main/java/org/sunbird/workflow/controller/DomainWorkFlowController.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.sunbird.workflow.config.Constants;
 import org.sunbird.workflow.models.Response;
 import org.sunbird.workflow.models.SearchCriteria;
 import org.sunbird.workflow.models.WfRequest;
@@ -21,7 +22,7 @@ public class DomainWorkFlowController {
     public ResponseEntity<Response> domainWfCreate(@RequestHeader String rootOrg, @RequestHeader String org,
                                              @RequestBody WfRequest wfRequest) {
         Response response = domainWhiteListWorkFlowService.createDomainWorkFlow(rootOrg, org, wfRequest);
-        return new ResponseEntity<>(response, HttpStatus.OK);
+        return new ResponseEntity<>(response, (HttpStatus) response.get(Constants.STATUS));
     }
 
     @PostMapping("/update")

--- a/src/main/java/org/sunbird/workflow/postgres/entity/WfDomainLookup.java
+++ b/src/main/java/org/sunbird/workflow/postgres/entity/WfDomainLookup.java
@@ -1,0 +1,43 @@
+package org.sunbird.workflow.postgres.entity;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "wf_domain_lookup", schema = "wingspan")
+public class WfDomainLookup extends Object{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "wf_domain_id", nullable = false)
+    private int id;
+
+    @Column(name = "wf_id")
+    private String wfId;
+
+    @Column(name = "domain_name")
+    private String domainName;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getWfId() {
+        return wfId;
+    }
+
+    public void setWfId(String wfId) {
+        this.wfId = wfId;
+    }
+
+    public String getDomainName() {
+        return domainName;
+    }
+
+    public void setDomainName(String domainName) {
+        this.domainName = domainName;
+    }
+}

--- a/src/main/java/org/sunbird/workflow/postgres/repo/WfDomainLookupRepo.java
+++ b/src/main/java/org/sunbird/workflow/postgres/repo/WfDomainLookupRepo.java
@@ -1,0 +1,10 @@
+package org.sunbird.workflow.postgres.repo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.sunbird.workflow.postgres.entity.WfDomainLookup;
+
+import java.util.List;
+
+public interface WfDomainLookupRepo  extends JpaRepository<WfDomainLookup, Integer> {
+    List<WfDomainLookup> findByDomainName(String domainValue);
+}

--- a/src/main/java/org/sunbird/workflow/service/impl/DomainWhiteListWorkFlowServiceImpl.java
+++ b/src/main/java/org/sunbird/workflow/service/impl/DomainWhiteListWorkFlowServiceImpl.java
@@ -23,10 +23,7 @@ import org.sunbird.workflow.service.UserProfileWfService;
 import org.sunbird.workflow.service.Workflowservice;
 import org.sunbird.workflow.utils.CassandraOperation;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -53,16 +50,31 @@ public class DomainWhiteListWorkFlowServiceImpl implements DomainWhiteListWorkFl
     @Override
     public Response createDomainWorkFlow(String rootOrg, String org, WfRequest wfRequest) {
         Response response = new Response();
-        HashMap<String, Object> updatedFieldValue = wfRequest.getUpdateFieldValues().stream().findFirst().get();
-        HashMap<String, String> toValue = (HashMap<String, String>) updatedFieldValue.get("toValue");
-        String domainValue =  toValue.get("domain").isEmpty() ? "" : toValue.get("domain");
-        List<WfDomainLookup> domainLookup = wfDomainLookupRepo.findByDomainName(domainValue);
-        if(CollectionUtils.isNotEmpty(domainLookup)) {
-            response.put(Constants.MESSAGE, Constants.DOMAIN_NAME_REQUEST_ALREADY_ERROR_MSG + ": " + domainValue);
-            response.put(Constants.STATUS, HttpStatus.ACCEPTED);
-            return response;
+        try {
+            HashMap<String, Object> updatedFieldValue = wfRequest.getUpdateFieldValues().stream().findFirst().get();
+            HashMap<String, String> toValue = (HashMap<String, String>) updatedFieldValue.get("toValue");
+            String domainValue = toValue.get("domain").isEmpty() ? "" : toValue.get("domain");
+            List<WfDomainLookup> domainLookup = wfDomainLookupRepo.findByDomainName(domainValue);
+            if (CollectionUtils.isNotEmpty(domainLookup)) {
+                response.put(Constants.MESSAGE, Constants.DOMAIN_NAME_REQUEST_EXIST_MSG + ": " + domainValue);
+                response.put(Constants.STATUS, HttpStatus.ACCEPTED);
+                return response;
+            }
+            response = workflowService.workflowTransition(rootOrg, org, wfRequest);
+            if (HttpStatus.OK.compareTo((HttpStatus) response.getResult().get(Constants.STATUS)) == 0) {
+                WfDomainLookup wfDomainLookup = new WfDomainLookup();
+                Map<String, Object> dataObject = (Map<String, Object>) response.getResult().getOrDefault(Constants.DATA, new HashMap());
+                List<String> wfIdList = (List<String>) dataObject.getOrDefault(Constants.WF_IDS_CONSTANT, new ArrayList());
+                wfDomainLookup.setWfId(wfIdList.get(0));
+                wfDomainLookup.setDomainName(domainValue);
+                wfDomainLookupRepo.save(wfDomainLookup);
+            }
+        } catch (Exception e) {
+            String errMsg = String.format("Failed to get the stats for course. Exception: ", e.getMessage());
+            response.put(Constants.ERROR_MESSAGE, errMsg);
+            response.put(Constants.STATUS, HttpStatus.INTERNAL_SERVER_ERROR);
+            response.setResponseCode(HttpStatus.INTERNAL_SERVER_ERROR);
         }
-        response = workflowService.workflowTransition(rootOrg, org, wfRequest);
         return response;
     }
 

--- a/src/main/java/org/sunbird/workflow/service/impl/DomainWhiteListWorkFlowServiceImpl.java
+++ b/src/main/java/org/sunbird/workflow/service/impl/DomainWhiteListWorkFlowServiceImpl.java
@@ -58,8 +58,8 @@ public class DomainWhiteListWorkFlowServiceImpl implements DomainWhiteListWorkFl
         String domainValue =  toValue.get("domain").isEmpty() ? "" : toValue.get("domain");
         List<WfDomainLookup> domainLookup = wfDomainLookupRepo.findByDomainName(domainValue);
         if(CollectionUtils.isNotEmpty(domainLookup)) {
-            response.put(Constants.ERROR_MESSAGE, Constants.DOMAIN_NAME_REQUEST_ALREADY_ERROR_MSG + ": " + domainValue);
-            response.put(Constants.STATUS, HttpStatus.BAD_REQUEST);
+            response.put(Constants.MESSAGE, Constants.DOMAIN_NAME_REQUEST_ALREADY_ERROR_MSG + ": " + domainValue);
+            response.put(Constants.STATUS, HttpStatus.ACCEPTED);
             return response;
         }
         response = workflowService.workflowTransition(rootOrg, org, wfRequest);

--- a/src/main/java/org/sunbird/workflow/service/impl/WorkflowServiceImpl.java
+++ b/src/main/java/org/sunbird/workflow/service/impl/WorkflowServiceImpl.java
@@ -22,11 +22,9 @@ import org.sunbird.workflow.exception.BadRequestException;
 import org.sunbird.workflow.exception.InvalidDataInputException;
 import org.sunbird.workflow.models.*;
 import org.sunbird.workflow.postgres.entity.WfAuditEntity;
-import org.sunbird.workflow.postgres.entity.WfDomainLookup;
 import org.sunbird.workflow.postgres.entity.WfStatusCountDTO;
 import org.sunbird.workflow.postgres.entity.WfStatusEntity;
 import org.sunbird.workflow.postgres.repo.WfAuditRepo;
-import org.sunbird.workflow.postgres.repo.WfDomainLookupRepo;
 import org.sunbird.workflow.postgres.repo.WfStatusRepo;
 import org.sunbird.workflow.producer.Producer;
 import org.sunbird.workflow.service.UserProfileWfService;
@@ -62,9 +60,6 @@ public class WorkflowServiceImpl implements Workflowservice {
 
 	@Autowired
 	private Producer producer;
-
-	@Autowired
-	private WfDomainLookupRepo wfDomainLookupRepo;
 
 	Logger log = LogManager.getLogger(WorkflowServiceImpl.class);
 
@@ -155,15 +150,6 @@ public class WorkflowServiceImpl implements Workflowservice {
 			applicationStatus.setComment(wfRequest.getComment());
 			applicationStatus.setServiceName(serviceName);
 			addModificationEntry(applicationStatus,userId,wfRequest.getAction(),role);
-			if (Constants.DOMAIN_SERVICE_NAME.equalsIgnoreCase(wfRequest.getServiceName())) {
-				WfDomainLookup wfDomainLookup = new WfDomainLookup();
-				wfDomainLookup.setWfId(applicationStatus.getWfId());
-				HashMap<String, Object> updatedFieldValue = wfRequest.getUpdateFieldValues().stream().findFirst().get();
-				HashMap<String, String> toValue = (HashMap<String, String>) updatedFieldValue.get("toValue");
-				String domainValue =  toValue.get("domain").isEmpty() ? "" : toValue.get("domain");
-				wfDomainLookup.setDomainName(domainValue);
-				wfDomainLookupRepo.save(wfDomainLookup);
-			}
 			wfStatusRepo.save(applicationStatus);
 			producer.push(configuration.getWorkFlowNotificationTopic(), wfRequest);
 			producer.push(configuration.getWorkflowApplicationTopic(), wfRequest);


### PR DESCRIPTION
For the use case Need to restrict the API to create only one WF request for target domain. When another user creates a request for same domain, need to return response mentioning this domain request already available. If necessary - increase the count of request received for a target domain