### PR TITLE
/getUserWFApplicationFields: API enhancement, changed response data from only key to Key-Value

### DIFF
--- a/src/main/java/org/sunbird/workflow/service/impl/WorkflowServiceImpl.java
+++ b/src/main/java/org/sunbird/workflow/service/impl/WorkflowServiceImpl.java
@@ -724,14 +724,14 @@ public class WorkflowServiceImpl implements Workflowservice {
 		List<String> updatedFieldValues = wfStatusRepo.findWfFieldsForUser(rootOrg, org, criteria.getServiceName(), criteria.getApplicationStatus(), wid);
 		TypeReference<List<HashMap<String, Object>>> typeRef = new TypeReference<List<HashMap<String, Object>>>() {
 		};
-		Set<String> fieldsSet = new HashSet<>();
+		Map<String,Object> toValuesMap = new HashMap<>();
 		for (String fields : updatedFieldValues) {
 			if (!StringUtils.isEmpty(fields)) {
 				try {
 					List<HashMap<String, Object>> values = mapper.readValue(fields, typeRef);
 					for (HashMap<String, Object> wffieldReq : values) {
 						HashMap<String, Object> toValueMap = (HashMap<String, Object>) wffieldReq.get("toValue");
-						fieldsSet.add(toValueMap.entrySet().iterator().next().getKey());
+						toValuesMap.put(toValueMap.entrySet().iterator().next().getKey(),toValueMap.entrySet().iterator().next().getValue());
 					}
 				} catch (IOException e) {
 					log.error("Exception occurred while parsing wf fields!");
@@ -741,7 +741,7 @@ public class WorkflowServiceImpl implements Workflowservice {
 		}
 		Response response = new Response();
 		response.put(Constants.MESSAGE, Constants.SUCCESSFUL);
-		response.put(Constants.DATA, fieldsSet);
+		response.put(Constants.DATA, toValuesMap);
 		response.put(Constants.STATUS, HttpStatus.OK);
 		return response;
 	}


### PR DESCRIPTION
At the moment, the API only provides the names of the fields that the user has sent for approval. However, the latest requirement demands us to include the value of these fields in the API response as well. To implement this, I have enhanced this API to return both the fields name and their values so that we can display the most up-to-date values in the edit profile section.